### PR TITLE
Added Get-MSSQLLinkPasswords to PostExploitation.psm1

### DIFF
--- a/PostExploitation/PostExploitation.psm1
+++ b/PostExploitation/PostExploitation.psm1
@@ -1505,6 +1505,7 @@ function Get-Webconfig
     }else{
         Write-Error "Appcmd.exe does not exist in the default location."
     }
+
 }
 
 function Get-MSSQLLinkPasswords{


### PR DESCRIPTION
Get-MSSQLLinkPasswords extracts and decrypts the connection credentials for all linked servers that use SQL Server authentication on all local MSSQL instances.
