### PR TITLE
Get-Help for Get-RegValue prints out an unnecessary "PS C:\Wind"

### DIFF
--- a/Registry/Registry.ps1
+++ b/Registry/Registry.ps1
@@ -541,8 +541,6 @@ function Set-RegValue
     PS C:\> $bindata = Get-RegValue -Hive HKCU -Key _deleteme -Name binval
     PS C:\> ([System.Text.Encoding]::ASCII).GetString($bindata)
     PowerShell
-
-PS C:\Wind
 #>
 function Get-RegValue
 {


### PR DESCRIPTION
PS C:\Users\Administrator\Desktop\Posh-SecMod-master\Registry> Get-Help Get-RegValue -Examples

NAME
    Get-RegValue

SYNOPSIS
    Retrives a the content of a specified value in a given key.

    -------------------------- EXAMPLE 1 --------------------------

    C:\PS>Getting the Windows Version fromt the registry


    PS C:\> Get-RegValue -Hive HKLM -key "SOFTWARE\Microsoft\Windows NT\CurrentVersion" -Name ProductName
    Windows 8 Enterprise




    -------------------------- EXAMPLE 2 --------------------------

    C:\PS>Read registry binary data and turn it in to ASCII String


    PS C:\> $bindata = Get-RegValue -Hive HKCU -Key _deleteme -Name binval
    PS C:\> ([System.Text.Encoding]::ASCII).GetString($bindata)
    PowerShell

    PS C:\Wind


PS C:\Users\Administrator\Desktop\Posh-SecMod-master\Registry>